### PR TITLE
Enable to set `AppFeedback_SlackApiUrl`

### DIFF
--- a/lib/fastlane/plugin/setup_app_feedback_sdk/actions/setup_app_feedback_sdk_action.rb
+++ b/lib/fastlane/plugin/setup_app_feedback_sdk/actions/setup_app_feedback_sdk_action.rb
@@ -14,6 +14,10 @@ module Fastlane
         SetInfoPlistValueAction.run(key: 'AppFeedback_SlackApiToken', value: params[:slack_api_token], path: plist)
         SetInfoPlistValueAction.run(key: 'AppFeedback_SlackChannel', value: params[:slack_channel], path: plist)
 
+        if params[:slack_api_url]
+          SetInfoPlistValueAction.run(key: 'AppFeedback_SlackApiUrl', value: params[:slack_api_url], path: plist)
+        end
+
         if other_action.git_branch
           SetInfoPlistValueAction.run(key: 'AppFeedback_Branch', value: other_action.git_branch, path: plist)
         end
@@ -123,6 +127,11 @@ module Fastlane
                                        env_name: "APP_FEEDBACK_SDK_SLACK_CHANNEL",
                                        description: "Slack channel",
                                        optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :slack_api_url,
+                                       env_name: "APP_FEEDBACK_SLACK_API_URL",
+                                       description: "Slack API URL",
+                                       optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :project,
                                        env_name: 'APP_FEEDBACK_SDK_PROJECT',

--- a/spec/setup_approduce_feedback_sdk_action_spec.rb
+++ b/spec/setup_approduce_feedback_sdk_action_spec.rb
@@ -60,5 +60,25 @@ EOL
       expect(plist).to include('AppFeedback_Branch')
       expect(plist).to include('dummy_branch')
     end
+
+    it 'Set Slack API URL to Info.plist' do
+      ff = Fastlane::FastFile.new.parse(<<EOL)
+lane :test do
+  setup_app_feedback_sdk(
+        project: __dir__ + '/../iOSTestApp/iOSTestApp.xcodeproj',
+        scheme: 'iOSTestApp',
+        configuration: 'Release',
+        slack_api_token: 'dummy_token',
+        slack_channel: 'dummy_channel',
+        slack_api_url: 'dummy_api_url'
+  )
+end
+EOL
+
+      ff.runner.execute(:test)
+
+      expect(plist).to include('AppFeedback_SlackApiUrl')
+      expect(plist).to include('dummy_api_url')
+    end
   end
 end


### PR DESCRIPTION
This PR is for https://github.com/yahoojapan/AppFeedback/pull/7 .